### PR TITLE
Develop

### DIFF
--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -36,7 +36,7 @@ def slider(
     fig, ax = plt.subplots()
     
     #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
-    self.x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
+    x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
     model_data_fine = fcn(params,x_data_fine)
 
     line, = ax.plot(x_data_fine, model_data_fine, **model_kwargs)
@@ -73,7 +73,7 @@ def slider(
         for param_name in param_sliders.keys():
             if params[param_name].vary:
                 params[param_name].set(value=param_sliders[param_name].val)
-        model = fcn(params, self.x_data_fine, *args, **kws)
+        model = fcn(params, x_data_fine, *args, **kws)
         old_bottom, old_top = ax.get_ylim()
         line.set_ydata(
             model,

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -36,7 +36,7 @@ def slider(
     fig, ax = plt.subplots()
     
     #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
-    x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
+    self.x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
     model_data_fine = fcn(params,x_data_fine)
 
     line, = ax.plot(x_data_fine, model_data_fine, **model_kwargs)
@@ -73,7 +73,7 @@ def slider(
         for param_name in param_sliders.keys():
             if params[param_name].vary:
                 params[param_name].set(value=param_sliders[param_name].val)
-        model = fcn(params, *args, **kws)
+        model = fcn(params, self.x_data_fine, *args, **kws)
         old_bottom, old_top = ax.get_ylim()
         line.set_ydata(
             model,

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -12,7 +12,8 @@ def slider(
     data=None,
     model_kwargs=None,
     data_kwargs=None,
-    model_fine = False
+    model_fine = False,
+    model_x = None
 ):
     # The parametrized function to be plotted
     if args is None:
@@ -37,13 +38,14 @@ def slider(
     
     #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
     if model_fine:
-        x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
-        model = fcn(params, x_data_fine,*args, **kws)
+        if model_x == None:
+            model_x = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
+        model = fcn(params, model_x,*args, **kws)
     else:
-        x_data_fine = x
+        model_x = x
         model = fcn(params, *args, **kws)
 
-    line, = ax.plot(x_data_fine, model, **model_kwargs)
+    line, = ax.plot(model_x, model, **model_kwargs)
     if data is not None:
         line2, = ax.plot(xdata, data, **data_kwargs)
 
@@ -78,7 +80,7 @@ def slider(
             if params[param_name].vary:
                 params[param_name].set(value=param_sliders[param_name].val)
         if model_fine:
-            model = fcn(params, x_data_fine, *args, **kws)
+            model = fcn(params, model_x, *args, **kws)
         else:
             model = fcn(params, *args, **kws)
         old_bottom, old_top = ax.get_ylim()
@@ -111,7 +113,7 @@ def slider(
 
     def reset_axes(event):
         if model_fine:
-            model = fcn(params, x_data_fine, *args, **kws)
+            model = fcn(params, model_x, *args, **kws)
         else:
             model = fcn(params, *args, **kws)
         if data is not None:

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -39,7 +39,7 @@ def slider(
     x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
     model_data_fine = fcn(params,x_data_fine)
 
-    line, = ax.plot(xdata, model, **model_kwargs)
+    line, = ax.plot(x_data_fine, model_data_fine, **model_kwargs)
     if data is not None:
         line2, = ax.plot(xdata, data, **data_kwargs)
 

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -37,7 +37,7 @@ def slider(
     
     #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
     x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
-    model_data_fine = fcn(params, x = x_data_fine)
+    model_data_fine = fcn(params,x_data_fine)
 
     line, = ax.plot(xdata, model, **model_kwargs)
     if data is not None:

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -26,7 +26,6 @@ def slider(
     for name in params:
         if np.isinf(params[name].min) or np.isinf(params[name].max):
             raise ValueError('Params must have finite bounds.')
-    model = fcn(params, *args, **kws)
     if x is None:
         xdata = np.arange(0, len(model))
     else:
@@ -37,9 +36,9 @@ def slider(
     
     #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
     x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
-    model_data_fine = fcn(params,x_data_fine)
+    model = fcn(params,x_data_fine *args, **kws)
 
-    line, = ax.plot(x_data_fine, model_data_fine, **model_kwargs)
+    line, = ax.plot(x_data_fine, model, **model_kwargs)
     if data is not None:
         line2, = ax.plot(xdata, data, **data_kwargs)
 
@@ -103,7 +102,7 @@ def slider(
         ax.set_ylim(bottom=init_min, top=init_max)
 
     def reset_axes(event):
-        model = fcn(params, *args, **kws)
+        model = fcn(params, x_data_fine, *args, **kws)
         if data is not None:
             ax.set_ylim(bottom=min(min(model), min(data)), top=max(max(model), max(data)))
         else:

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -34,6 +34,11 @@ def slider(
 
     # Create the figure and the line that we will manipulate
     fig, ax = plt.subplots()
+    
+    #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
+    x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
+    model_data_fine = fcn(params, x = x_data_fine)
+
     line, = ax.plot(xdata, model, **model_kwargs)
     if data is not None:
         line2, = ax.plot(xdata, data, **data_kwargs)

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -12,6 +12,7 @@ def slider(
     data=None,
     model_kwargs=None,
     data_kwargs=None,
+    model_fine = False
 ):
     # The parametrized function to be plotted
     if args is None:
@@ -35,8 +36,12 @@ def slider(
     fig, ax = plt.subplots()
     
     #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
-    x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
-    model = fcn(params,x_data_fine, *args, **kws)
+    if model_fine:
+        x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
+        model = fcn(params, x_data_fine,*args, **kws)
+    else:
+        x_data_fine = x
+        model = fcn(params, *args, **kws)
 
     line, = ax.plot(x_data_fine, model, **model_kwargs)
     if data is not None:
@@ -72,7 +77,10 @@ def slider(
         for param_name in param_sliders.keys():
             if params[param_name].vary:
                 params[param_name].set(value=param_sliders[param_name].val)
-        model = fcn(params, x_data_fine, *args, **kws)
+        if model_fine:
+            model = fcn(params, x_data_fine, *args, **kws)
+        else:
+            model = fcn(params, *args, **kws)
         old_bottom, old_top = ax.get_ylim()
         line.set_ydata(
             model,
@@ -102,7 +110,10 @@ def slider(
         ax.set_ylim(bottom=init_min, top=init_max)
 
     def reset_axes(event):
-        model = fcn(params, x_data_fine, *args, **kws)
+        if model_fine:
+            model = fcn(params, x_data_fine, *args, **kws)
+        else:
+            model = fcn(params, *args, **kws)
         if data is not None:
             ax.set_ylim(bottom=min(min(model), min(data)), top=max(max(model), max(data)))
         else:

--- a/lmfit_slider/slider.py
+++ b/lmfit_slider/slider.py
@@ -36,7 +36,7 @@ def slider(
     
     #creates finer spaced x-data so that you can clearly see in-between the points you are interpolating
     x_data_fine = np.linspace(np.amin(xdata), np.amax(xdata), 5000)
-    model = fcn(params,x_data_fine *args, **kws)
+    model = fcn(params,x_data_fine, *args, **kws)
 
     line, = ax.plot(x_data_fine, model, **model_kwargs)
     if data is not None:


### PR DESCRIPTION
Dear Bryan,

It was slightly sub-optimal that the lmfit-slider only plots model function points where there are data points for the original function, which for frequency domain fitting with only 10 data points can be confusing or misleading, since the default option in lmfit-slider plots and interpolates between the (sometimes) sparse data points, meaning that any peak structure smaller than the data pixels is hidden.

This pull request automatically plots 5000 points, meaning that for the model function, one can see finer structure.

Take a look at the code and let me know what you think.

Karna